### PR TITLE
Keyboard accessibility

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,5 +1,5 @@
 {
   "tasks": {
-    "serve": "deno run --allow-net --allow-read --watch server/main.ts"
+    "serve": "deno run --allow-net --allow-read --watch=static/ server/main.ts"
   }
 }

--- a/server/template.ts
+++ b/server/template.ts
@@ -20,8 +20,8 @@ export function buildDocument(data: Data) {
       ${buildHead(data)}
 
       <body>
-        <input id="open" type="checkbox" class="control" />
-        <input id="create" type="checkbox" class="control" />
+        <input id="open" type="checkbox" class="control" tabindex="1" aria-label="open/close envelope" />
+        <input id="create" type="checkbox" class="control" tabindex="2" aria-label="open/close dialog" />
 
         <div class="envelope-container">
           <label for="open">
@@ -146,7 +146,12 @@ function buildLetterContents(data: Data) {
       </p>
       <p class="button-write-letter-container">
         <label for="create">
-          <span class="button" role="button">
+          <span class="button" role="button" id="open-create">
+            ${strings[lang]["Write a custom letter"]}!
+          </span>
+        </label>
+        <label class="reverse-hidden">
+          <span class="button">
             ${strings[lang]["Write a custom letter"]}!
           </span>
         </label>
@@ -173,11 +178,15 @@ function buildDialog({ lang }: Data) {
             <div class="dialog-input dialog-row-2">
               <input type="text" name="${urlParamsNames.flag}" id="input-f" maxlength="100" />
             </div>
-            <label for="create" class="dialog-label button">
+            <span class="dialog-label button reverse-hidden">
+              ${strings[lang]["Cancel"]}
+            </span>
+            <label for="create" class="dialog-label button" id="close-create">
               ${strings[lang]["Cancel"]}
             </label>
             <div class="dialog-input dialog-submit">
               <input type="hidden" name="${urlParamsNames.encode}" />
+              <span class="button reverse-hidden">${strings[lang]["Create"]}</span>
               <input type="submit" value="${strings[lang]["Create"]}" class="button" />
             </div>
           </form>

--- a/static/main.css
+++ b/static/main.css
@@ -446,7 +446,7 @@ body {
   transition-delay: 0s, calc(var(--dialog-transition-duration) * 0.3);
 }
 
-#create:checked ~ * .dialog {
+#open:checked + #create:checked ~ * .dialog {
   z-index: 5;
   transform: translate(-98%, -20%);
 
@@ -466,7 +466,7 @@ body {
   transition-delay: calc(var(--dialog-transition-duration) * 0.7);
 }
 
-#create:checked ~ * .dialog-animation-helper-vertical {
+#open:checked + #create:checked ~ * .dialog-animation-helper-vertical {
   transform: translateY(20%);
 
   transition-delay: 0s;
@@ -484,7 +484,7 @@ body {
   transition-delay: 0s;
 }
 
-#create:checked ~ * .dialog-animation-helper-horizontal {
+#open:checked + #create:checked ~ * .dialog-animation-helper-horizontal {
   transform: translateX(100%);
 
   transition-delay: calc(var(--dialog-transition-duration) * 0.4);
@@ -521,9 +521,9 @@ body {
   text-align: center;
 }
 
-#create:checked ~ * .dialog-contents input,
-#create:checked ~ * .dialog-contents label,
-#create:checked ~ * .dialog-contents .button {
+#open:checked + #create:checked ~ * .dialog-contents input,
+#open:checked + #create:checked ~ * .dialog-contents label,
+#open:checked + #create:checked ~ * .dialog-contents .button {
   pointer-events: all;
 }
 
@@ -547,10 +547,6 @@ body {
 /*****************************************************************************\
  *                                OTHER                                      *
 \*****************************************************************************/
-
-.control {
-  display: none;
-}
 
 .button {
   font-size: 0.9rem;
@@ -616,4 +612,36 @@ body {
   color: var(--language-picker-text-color);
 
   border-radius: calc(var(--size) * 0.2);
+}
+
+/*****************************************************************************\
+ *                                 A11y                                      *
+\*****************************************************************************/
+
+.control {
+  opacity: 0;
+}
+
+
+body:has(#create:checked) #open,
+#open:not(:checked) ~ #create,
+#open:not(:checked) ~ * .letter label,
+#open:checked ~ * .letter label.reverse-hidden,
+#create:not(:checked) ~ * .dialog-contents input,
+#create:checked ~ * .dialog-contents .reverse-hidden {
+  display: none;
+}
+
+#open:not(:checked) ~ * .letter label.reverse-hidden,
+#create:not(:checked) ~ * .dialog-contents .reverse-hidden {
+  display: block;
+}
+
+#open:focus ~ * .envelope-container-bottom {
+  outline: black dashed 3px;
+}
+
+#create:focus:not(:checked) ~ * #open-create,
+#create:focus:checked ~ * #close-create {
+  outline: auto;
 }

--- a/static/main.css
+++ b/static/main.css
@@ -622,13 +622,16 @@ body {
   opacity: 0;
 }
 
-
-body:has(#create:checked) #open,
 #open:not(:checked) ~ #create,
 #open:not(:checked) ~ * .letter label,
 #open:checked ~ * .letter label.reverse-hidden,
 #create:not(:checked) ~ * .dialog-contents input,
+#create:not(:checked) ~ * .dialog-contents #close-create,
 #create:checked ~ * .dialog-contents .reverse-hidden {
+  display: none;
+}
+
+body:has(#create:checked) #open {
   display: none;
 }
 
@@ -637,11 +640,11 @@ body:has(#create:checked) #open,
   display: block;
 }
 
-#open:focus ~ * .envelope-container-bottom {
-  outline: black dashed 3px;
-}
-
+#open:focus ~ * .envelope-container-bottom,
 #create:focus:not(:checked) ~ * #open-create,
-#create:focus:checked ~ * #close-create {
-  outline: auto;
+#create:focus:checked ~ * #close-create,
+input:focus,
+.button:focus,
+a:focus {
+  outline: black dashed 3px;
 }


### PR DESCRIPTION
To make the page keyboard accessible without using any JavaScript, we need to be smart about which elements are focusable at any given time.

Initially only #open is focusable. When this element is focused, the envelope is outlined.

When #open is checked, #create becomes focusable. When #create is focused and unchecked, the "Create own letter" button is outlined. When #create is focused and checked, the "Cancel" button is outlined.

To prevent users being able to tab to the input fields inside of the dialog, when the dialog is closed, these elements are initially marked as unfocusable. Only when #create is checked do they become focusable.

To make elements unfocusable, `display: none` is used. This has the obvious drawback of causing elements to not be displayed anymore. To work around this, "fake" static elements are unhidden when the primary interactive elements get hidden.

Finally, we want to prevent users from closing the envelope without first closing the dialog. Without using JavaScript, this is only possible in browsers that support :has[^1] (Safari). This is done by making #open unfocusable when #create is checked. For browsers that do not support has, users can use keyboard navigation to close the envelope without first closing the dialog. To provide a graceful fallback for these browsers, the dialog has been updated to automatically close with the envelope when it is closed.

[^1]: This is because the `~` (next sibling) selector does not work for previous sibings in the node tree. See [this StackOverflow post](https://stackoverflow.com/questions/1817792/is-there-a-previous-sibling-selector).