### PR TITLE
RFC4648 compliant base64 encoder/decoder

### DIFF
--- a/server/params.ts
+++ b/server/params.ts
@@ -6,11 +6,11 @@ export const urlParamsNames = {
 } as const;
 
 export function encode(name: string | undefined, flag: string | undefined) {
-  return btoa(`${escapeColon(name ?? "")}:${escapeColon(flag ?? "")}`);
+  return btoa(unescape(encodeURIComponent(`${escapeColon(name ?? "")}:${escapeColon(flag ?? "")}`)));
 }
 
 export function decode(encoded: string) {
-  return atob(encoded)
+  return decodeURIComponent(escape(atob(encoded))
     .split(/(?<!:):(?!:)/)
     .map(unescapeColon);
 }

--- a/server/params.ts
+++ b/server/params.ts
@@ -10,7 +10,7 @@ export function encode(name: string | undefined, flag: string | undefined) {
 }
 
 export function decode(encoded: string) {
-  return decodeURIComponent(escape(atob(encoded))
+  return decodeURIComponent(escape(atob(encoded)))
     .split(/(?<!:):(?!:)/)
     .map(unescapeColon);
 }


### PR DESCRIPTION
This PR makes the base64 encoder/decoder [RFC4648](https://tools.ietf.org/html/rfc4648#section-4) compliant which can handle UTF-8 correctly.